### PR TITLE
Add event and helpers to enable dynamic worker creation and release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "graphile-worker",
-  "version": "0.13.0",
+  "name": "@liteflow/graphile-worker",
+  "version": "0.13.0-event-pool-listen-workersAreBusy-1",
   "description": "Job queue for PostgreSQL",
   "main": "dist/index.js",
   "scripts": {
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/graphile/worker.git"
+    "url": "git+ssh://git@github.com/liteflow-labs/graphile-worker.git"
   },
   "keywords": [
     "postgresql",
@@ -36,9 +36,9 @@
   "author": "Benjie Gillam <code@benjiegillam.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/graphile/worker/issues"
+    "url": "https://github.com/liteflow-labs/graphile-worker/issues"
   },
-  "homepage": "https://github.com/graphile/worker#readme",
+  "homepage": "https://github.com/liteflow-labs/graphile-worker#readme",
   "dependencies": {
     "@graphile/logger": "^0.2.0",
     "@types/debug": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liteflow/graphile-worker",
-  "version": "0.13.0-event-pool-listen-workersAreBusy-1",
+  "version": "0.13.0-event-pool-listen-workersAreBusy-5",
   "description": "Job queue for PostgreSQL",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liteflow/graphile-worker",
-  "version": "0.13.0-event-pool-listen-workersAreBusy-5",
+  "version": "0.13.0-event-pool-listen-workersAreBusy-6",
   "description": "Job queue for PostgreSQL",
   "main": "dist/index.js",
   "scripts": {

--- a/sql/000011.sql
+++ b/sql/000011.sql
@@ -1,0 +1,11 @@
+DROP TRIGGER _900_notify_worker ON graphile_worker.jobs;
+CREATE TRIGGER _900_notify_worker AFTER INSERT ON graphile_worker.jobs FOR EACH ROW EXECUTE PROCEDURE graphile_worker.tg_jobs__notify_new_jobs();
+
+CREATE OR REPLACE FUNCTION graphile_worker.tg_jobs__notify_new_jobs() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  perform pg_notify('jobs:insert', new.id::text);
+  return new;
+end;
+$$;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -565,6 +565,11 @@ export type WorkerEventMap = {
   };
 
   /**
+   * When a worker pool receives a job notification but all workers are busy
+   */
+  "pool:listen:workersAreBusy": { workerPool: WorkerPool };
+
+  /**
    * When a worker pool is released
    */
   "pool:release": { pool: WorkerPool };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -292,6 +292,8 @@ export interface WorkerPool {
   release: () => Promise<void>;
   gracefulShutdown: (message: string) => Promise<void>;
   promise: Promise<void>;
+  releaseWorker: (workerId: string) => Promise<void>;
+  createWorker: () => void;
 }
 
 export interface Runner {
@@ -299,6 +301,7 @@ export interface Runner {
   addJob: AddJobFunction;
   promise: Promise<void>;
   events: WorkerEvents;
+  workerPool: WorkerPool;
 }
 
 export interface Cron {

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,7 +276,6 @@ export function runTaskList(
     function handleNotification() {
       if (listenForChangesClient === client) {
         // Find a worker that's available
-        // Find a worker that's available
         if (!workers.some((worker) => worker.nudge())) {
           events.emit("pool:listen:workersAreBusy", { workerPool });
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,6 +149,25 @@ export function runTaskList(
       allWorkerPools.splice(idx, 1);
     },
 
+    releaseWorker: async (workerId) => {
+      console.log(
+        "workers",
+        workers.map((worker) => worker.workerId),
+      );
+      const index = workers.findIndex((worker) => worker.workerId === workerId);
+      console.log("index", index);
+      if (index < 0) {
+        throw new Error(`${workerId} not found`);
+      }
+      await Promise.all(
+        workers.splice(index, 1).map((worker) => worker.release()),
+      );
+    },
+
+    createWorker: () => {
+      workers.push(makeNewWorker(options, tasks, withPgClient));
+    },
+
     // Make sure we clean up after ourselves even if a signal is caught
     async gracefulShutdown(message: string) {
       events.emit("pool:gracefulShutdown", { pool: this, message });

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,12 +150,7 @@ export function runTaskList(
     },
 
     releaseWorker: async (workerId) => {
-      console.log(
-        "workers",
-        workers.map((worker) => worker.workerId),
-      );
       const index = workers.findIndex((worker) => worker.workerId === workerId);
-      console.log("index", index);
       if (index < 0) {
         throw new Error(`${workerId} not found`);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,7 +262,10 @@ export function runTaskList(
     function handleNotification() {
       if (listenForChangesClient === client) {
         // Find a worker that's available
-        workers.some((worker) => worker.nudge());
+        // Find a worker that's available
+        if (!workers.some((worker) => worker.nudge())) {
+          events.emit("pool:listen:workersAreBusy", { workerPool });
+        }
       }
     }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -106,6 +106,7 @@ export const run = async (
       addJob,
       promise: workerPool.promise,
       events,
+      workerPool,
     };
   } catch (e) {
     await release();


### PR DESCRIPTION
Based on `v0.13.0`

- add new event `pool:listen:workersAreBusy`. Emitted when a worker pool receives a job notification but all workers are busy
- add helpers functions `createWorker` and `releaseWorker` on `WorkerPool`
- add `workerPool` to `Runner`
- emit database notification `jobs:insert` for each job added

Published on npm: https://npmjs.com/package/@liteflow/graphile-worker
Last version published is: `0.13.0-event-pool-listen-workersAreBusy-6`